### PR TITLE
Correctly use "2" for the day in the date format

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,7 @@
                 <div class="feat">
                     <h5 class="page-date">
                     <time datetime="" itemprop="datePublished">
-                    {{ .Date.Format "1. January 2006" }}
+                    {{ .Date.Format "2. January 2006" }}
                     </time>
                     </h5>
                 </div>

--- a/layouts/partials/post-list.html
+++ b/layouts/partials/post-list.html
@@ -7,7 +7,7 @@
                 <a href="{{ .Permalink }}" itemprop="url">
                     <div class="p-wrap">
                         <time datetime="" itemprop="datePublished">
-                        {{ .Date.Format "01 Jan 2006" }}
+                        {{ .Date.Format "02 Jan 2006" }}
                         </time>
                         <p itemprop="name headline">{{ .Title }}</p>
                     </div>


### PR DESCRIPTION
The Go [time package](https://golang.org/pkg/time/#pkg-constants) defines the reference time used in the layouts as "Mon
Jan 2 15:04:05 MST 2006". Using "1" for the day makes the date formatting behave incorrectly (the post I created today showed "1. January 2016").

Thanks for the port!
