### PR TITLE
optional google search bar added

### DIFF
--- a/layouts/partials/off-canvas.html
+++ b/layouts/partials/off-canvas.html
@@ -11,6 +11,27 @@
         {{ end }}
     </div>
     <nav>
+
+        {{ if .Site.Params.offcanvas.search_enabled }}
+
+        {{ with .Site.Params.offcanvas.search }}
+        <h6>{{ . }}</h6>
+        {{ end }}
+
+        <div>
+            <form name="google-search" method="get" action="http://www.google.com/search" target="_blank">
+                <input type="hidden" name="sitesearch" value="{{ .Site.BaseURL }}" />
+                <input name="q" type="text" />
+                <input type="submit" name="sa" value="Google" />
+            </form>
+        </div>
+
+        {{end}}
+
+        {{ with .Site.Params.offcanvas.subscribe }}
+        <h6>{{ . }}</h6>
+        {{ end }}
+
         {{ with .Site.Params.offcanvas.subscribe }}
         <h6>{{ . }}</h6>
         {{ end }}

--- a/layouts/partials/off-canvas.html
+++ b/layouts/partials/off-canvas.html
@@ -32,10 +32,6 @@
         <h6>{{ . }}</h6>
         {{ end }}
 
-        {{ with .Site.Params.offcanvas.subscribe }}
-        <h6>{{ . }}</h6>
-        {{ end }}
-
         <ul>
             <li><a target="_blank" href="{{ .Site.BaseURL }}index.xml">RSS feed</a></li>
         </ul>


### PR DESCRIPTION
To enable search bar, set
search_enabled = true
in config.toml

Search queries are handles by google.com, the search is restricted to 'site: baseurl'.

Two parameters are necessary in config.toml:
[params.offcanvas]
    search_enabled = true
    search = "Search"
